### PR TITLE
Feature/add json report

### DIFF
--- a/src/main/java/org/sonatype/nexus/plugins/report/internal/ReportService.java
+++ b/src/main/java/org/sonatype/nexus/plugins/report/internal/ReportService.java
@@ -71,7 +71,7 @@ public class ReportService extends ComponentSupport {
      * @return a list of {@link ComponentInfos}
      * @throws RepositoryNotFoundException
      */
-    private List<ComponentInfos> getComponentsInfos(final Repository repository) throws RepositoryNotFoundException {
+    public List<ComponentInfos> getComponentsInfos(final Repository repository) throws RepositoryNotFoundException {
         List<ComponentInfos> componentsInfos = new ArrayList<>();
         if (null == repository) {
             throw new RepositoryNotFoundException();

--- a/src/main/java/org/sonatype/nexus/plugins/report/internal/rest/ReportResource.java
+++ b/src/main/java/org/sonatype/nexus/plugins/report/internal/rest/ReportResource.java
@@ -96,6 +96,10 @@ public class ReportResource extends ComponentSupport implements Resource, Report
     @Produces(MediaType.APPLICATION_JSON)
     @RequiresPermissions(ReportApiConstants.REPORT_API_PERMISSION)
     public Response downloadJsonReport(@PathParam("repositoryName") final String repositoryName) {
+        if (null == repositoryName) {
+            return Response.status(Response.Status.BAD_REQUEST).type(MediaType.TEXT_HTML_TYPE)
+                    .entity(ReportApiConstants.REPOSITORY_NAME_REQUIRED).build();
+        }
         try {
             Repository repository = repositoryManager.get(repositoryName);
             if (null == repository) {

--- a/src/main/java/org/sonatype/nexus/plugins/report/internal/rest/doc/ReportResourceDoc.java
+++ b/src/main/java/org/sonatype/nexus/plugins/report/internal/rest/doc/ReportResourceDoc.java
@@ -38,4 +38,9 @@ public interface ReportResourceDoc {
             @ApiResponse(code = 400, message = ReportApiConstants.REPOSITORY_NAME_REQUIRED) })
     Response downloadExcelReport(@ApiParam(ReportApiConstants.REPOSITORY_NAME_DESCRIPTION) final String repositoryName)
             throws IOException;
+    @ApiOperation(value = ReportApiConstants.DOWNLOAD_REPORT_API_OPERATION)
+    @ApiResponses(value = { @ApiResponse(code = 403, message = ReportApiConstants.REPORT_PERMISSION_DENIED),
+            @ApiResponse(code = 400, message = ReportApiConstants.REPOSITORY_NAME_REQUIRED) })
+    Response downloadJsonReport(@ApiParam(ReportApiConstants.REPOSITORY_NAME_DESCRIPTION) final String repositoryName)
+            throws IOException;
 }

--- a/src/test/java/org/sonatype/nexus/plugins/report/internal/rest/ReportResourceTest.java
+++ b/src/test/java/org/sonatype/nexus/plugins/report/internal/rest/ReportResourceTest.java
@@ -16,8 +16,6 @@ import org.sonatype.goodies.testsupport.TestSupport;
 import org.sonatype.nexus.common.event.EventManager;
 import org.sonatype.nexus.common.wonderland.DownloadService.Download;
 import org.sonatype.nexus.plugins.report.internal.ReportService;
-import org.sonatype.nexus.plugins.report.internal.rest.ReportApiConstants;
-import org.sonatype.nexus.plugins.report.internal.rest.ReportResource;
 import org.sonatype.nexus.repository.Format;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.manager.RepositoryManager;
@@ -52,14 +50,14 @@ public class ReportResourceTest extends TestSupport {
     }
 
     @Test
-    public void should_return_Parameter_repositoryName_is_required() {
+    public void downloadExcelReport_should_return_Parameter_repositoryName_is_required() {
         Response response = reportResource.downloadExcelReport(null);
         assert response.getStatus() == 400;
         assert response.getEntity().toString() == ReportApiConstants.REPOSITORY_NAME_REQUIRED;
     }
 
     @Test
-    public void should_return_Repository_not_found() {
+    public void downloadExcelReport_should_return_Repository_not_found() {
         String repositoryName = "test";
         when(repositoryManager.get(repositoryName)).thenReturn(null);
         Response response = reportResource.downloadExcelReport("test");
@@ -68,7 +66,7 @@ public class ReportResourceTest extends TestSupport {
     }
 
     @Test
-    public void should_return_You_don_t_have_access_to_this_repository() {
+    public void downloadExcelReport_should_return_You_don_t_have_access_to_this_repository() {
         String repositoryName = "test";
         when(repositoryManager.get(repositoryName)).thenReturn(repository);
         when(repositoryPermissionChecker.userCanBrowseRepository(repository)).thenReturn(false);
@@ -78,7 +76,7 @@ public class ReportResourceTest extends TestSupport {
     }
 
     @Test
-    public void should_return_INTERNAL_SERVER_ERROR() {
+    public void downloadExcelReport_should_return_INTERNAL_SERVER_ERROR() {
         String repositoryName = "test";
         when(repositoryManager.get(repositoryName)).thenReturn(repository);
         when(repositoryPermissionChecker.userCanBrowseRepository(repository)).thenReturn(true);
@@ -93,7 +91,7 @@ public class ReportResourceTest extends TestSupport {
     }
 
     @Test
-    public void should_return_response_with_empty_file() {
+    public void downloadExcelReport_should_return_response_with_empty_file() {
         String repositoryName = "test";
         when(repositoryManager.get(repositoryName)).thenReturn(repository);
         when(repositoryPermissionChecker.userCanBrowseRepository(repository)).thenReturn(true);
@@ -109,6 +107,46 @@ public class ReportResourceTest extends TestSupport {
         assert response.getHeaders().containsKey(com.google.common.net.HttpHeaders.CONTENT_LENGTH);
         assert response.getHeaders().get(com.google.common.net.HttpHeaders.CONTENT_LENGTH).get(0).toString()
                 .equals("0");
+    }
+    
+    @Test
+    public void downloadJsonReport_should_return_Parameter_repositoryName_is_required() {
+        Response response = reportResource.downloadJsonReport(null);
+        assert response.getStatus() == 400;
+        assert response.getEntity().toString() == ReportApiConstants.REPOSITORY_NAME_REQUIRED;
+    }
+
+    @Test
+    public void downloadJsonReport_should_return_Repository_not_found() {
+        String repositoryName = "test";
+        when(repositoryManager.get(repositoryName)).thenReturn(null);
+        Response response = reportResource.downloadJsonReport("test");
+        assert response.getStatus() == 400;
+        assert response.getEntity().toString() == ReportApiConstants.REPOSITORY_NOT_FOUND;
+    }
+
+    @Test
+    public void downloadJsonReport_should_return_You_don_t_have_access_to_this_repository() {
+        String repositoryName = "test";
+        when(repositoryManager.get(repositoryName)).thenReturn(repository);
+        when(repositoryPermissionChecker.userCanBrowseRepository(repository)).thenReturn(false);
+        Response response = reportResource.downloadJsonReport("test");
+        assert response.getStatus() == 403;
+        assert response.getEntity().toString() == ReportApiConstants.REPOSITORY_PERMISSION_DENIED;
+    }
+
+    @Test
+    public void downloadJsonReport_should_return_INTERNAL_SERVER_ERROR() {
+        String repositoryName = "test";
+        when(repositoryManager.get(repositoryName)).thenReturn(repository);
+        when(repositoryPermissionChecker.userCanBrowseRepository(repository)).thenReturn(true);
+        try {
+            when(reportService.getComponentsInfos(repository)).thenThrow(new RepositoryNotFoundException());
+        } catch (RepositoryNotFoundException e) {
+            Assert.fail();
+        }
+        Response response = reportResource.downloadJsonReport("test");
+        assert response.getStatus() == 500;
     }
 
 }


### PR DESCRIPTION
New endpoint to get the report as Json for a repository.
It is available from /system/api on the UI.

### Example : 

**Curl**
`curl -X GET "http://localhost:8081/service/rest/v1/report/json/maven-releases" -H  "accept: application/json"`

**Response code**
`200`

**Response headers**
```
 content-length: 735  content-type: application/json  date: Wed, 30 Sep 2020 23:21:09 GMT  server: Nexus/3.24.0-02 (OSS)  x-content-type-options: nosniff 
```

**Response body**
```
[
  {
    "group": "org.sonatype.nexus.plugins",
    "name": "nexus-report-plugin",
    "version": "0.1.2",
    "format": "maven2",
    "size": 3686343,
    "sizeMB": 3.52,
    "sizeGB": 0,
    "createdBy": "admin",
    "lastUpdated": "2020-10-01T01:17:52",
    "lastDownloaded": "never",
    "encoded": "bWF2ZW4tcmVsZWFzZXM6ODg0OTFjZDFkMTg1ZGQxMzYzMjY4ZjIyMGU0NWQ3ZGU"
  },
  {
    "group": "org.sonatype.nexus",
    "name": "nexus-ui-plugin",
    "version": "3.24.0-02",
    "format": "maven2",
    "size": 5494,
    "sizeMB": 0.01,
    "sizeGB": 0,
    "createdBy": "admin",
    "lastUpdated": "2020-10-01T01:20:41",
    "lastDownloaded": "never",
    "encoded": "bWF2ZW4tcmVsZWFzZXM6YzBhYzJhYjZjNWU5M2E0YTc2Zjc5OTEwMjllMDk0Yzg"
  }
]
```



