### PR TITLE
add jaCoCoArgLine and overrides maven-surefire-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,24 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
+  
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <argLine>
+              ${jaCoCoArgLine}
+              -Xmx300M
+              -XX:MaxDirectMemorySize=2G
+              -XX:+HeapDumpOnOutOfMemoryError
+              -XX:HeapDumpPath=${project.build.directory}/surefire-reports
+            </argLine>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
@@ -131,6 +147,9 @@
             <goals>
               <goal>prepare-agent</goal>
             </goals>
+            <configuration>
+              <propertyName>jaCoCoArgLine</propertyName>
+            </configuration>
           </execution>
           <execution>
             <id>jacoco-site</id>


### PR DESCRIPTION
Fix Jacoco configuration for Coveralls